### PR TITLE
feat: logos, agentic AI highlight, and URL fields on resume and admin

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model ContractorCompany {
   id          String       @id @default(auto()) @map("_id") @db.ObjectId
   name        String
   logo        String?
+  url         String?
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
   experiences Experience[]

--- a/src/app/api/contractor-companies/route.ts
+++ b/src/app/api/contractor-companies/route.ts
@@ -31,9 +31,9 @@ export const POST = async (req: Request) => {
       return Response.json({ error: "Invalid input" }, { status: 400 });
     }
 
-    const { name, logo } = parseResult.data;
+    const { name, logo, url } = parseResult.data;
     const company = await prisma.contractorCompany.create({
-      data: { name, logo },
+      data: { name, logo, url: url || null },
     });
     return Response.json(company, { status: 201 });
   } catch (error) {
@@ -55,14 +55,14 @@ export const PUT = async (req: Request) => {
       return Response.json({ error: "Invalid input" }, { status: 400 });
     }
 
-    const { id, name, logo } = parseResult.data;
+    const { id, name, logo, url } = parseResult.data;
     const existing = await prisma.contractorCompany.findUnique({ where: { id } });
     if (!existing)
       return Response.json({ error: "Not found" }, { status: 404 });
 
     const updated = await prisma.contractorCompany.update({
       where: { id },
-      data: { name, logo },
+      data: { name, logo, url: url || null },
     });
     return Response.json(updated, { status: 200 });
   } catch (error) {

--- a/src/components/AddEditContractorCompanyDialog.tsx
+++ b/src/components/AddEditContractorCompanyDialog.tsx
@@ -45,6 +45,7 @@ const AddEditContractorCompanyDialog = ({
     defaultValues: {
       name: companyToEdit?.name || "",
       logo: companyToEdit?.logo || undefined,
+      url: companyToEdit?.url || "",
     },
   });
 
@@ -160,6 +161,19 @@ const AddEditContractorCompanyDialog = ({
                     <FormLabel>Name</FormLabel>
                     <FormControl>
                       <Input placeholder="Contractor / Agency name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Website URL</FormLabel>
+                    <FormControl>
+                      <Input type="url" placeholder="https://company.com" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/components/AddEditExperienceDialog.tsx
+++ b/src/components/AddEditExperienceDialog.tsx
@@ -60,6 +60,7 @@ const AddEditExperienceDialog = ({
       company: experienceToEdit?.company || "",
       dates: experienceToEdit?.dates || "",
       techStack: experienceToEdit?.techStack || [],
+      link: experienceToEdit?.link || undefined,
       content: experienceToEdit?.content || "",
       contractorCompanyId: experienceToEdit?.contractorCompanyId || undefined,
     },
@@ -225,6 +226,19 @@ const AddEditExperienceDialog = ({
                     <FormLabel>Dates</FormLabel>
                     <FormControl>
                       <Input placeholder="Dates" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="link"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Link</FormLabel>
+                    <FormControl>
+                      <Input type="url" placeholder="https://project-or-company.com" {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/src/components/resume/ContractorGroupedExperience.tsx
+++ b/src/components/resume/ContractorGroupedExperience.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { Sparkles } from "lucide-react";
+import { ExternalLink, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ExperienceWithContractor } from "@/components/SortableExperienceGrid";
 
@@ -10,24 +10,13 @@ interface ContractorGroupedExperienceProps {
   experiences: ExperienceWithContractor[];
 }
 
-// ---------- helpers ----------
+// ---------- logo helpers ----------
 
-function ContractorLogo({
-  src,
-  name,
-  size = 40,
-}: {
-  src: string;
-  name: string;
-  size?: number;
-}) {
+function ContractorLogo({ src, name }: { src: string; name: string }) {
   const [failed, setFailed] = useState(false);
   if (failed) {
     return (
-      <div
-        style={{ width: size, height: size }}
-        className="flex shrink-0 items-center justify-center rounded-md bg-muted text-sm font-bold text-muted-foreground"
-      >
+      <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-sm font-bold text-muted-foreground">
         {name[0]}
       </div>
     );
@@ -36,83 +25,136 @@ function ContractorLogo({
     <Image
       src={src}
       alt={`${name} logo`}
-      width={size}
-      height={size}
+      width={40}
+      height={40}
       className="shrink-0 rounded-md object-contain"
       onError={() => setFailed(true)}
     />
   );
 }
 
-function AgenticBadge({ small = false }: { small?: boolean }) {
+function SmallLogo({ src, company }: { src: string; company: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) return null;
   return (
-    <span
-      className={`inline-flex items-center gap-1 rounded-full bg-blue-100 font-medium text-blue-700 dark:bg-blue-900 dark:text-blue-300 ${
-        small ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-xs"
-      }`}
-    >
-      <Sparkles size={small ? 9 : 11} />
+    <Image
+      src={src}
+      alt={`${company} logo`}
+      width={20}
+      height={20}
+      className="mt-0.5 shrink-0 rounded object-contain"
+      onError={() => setFailed(true)}
+    />
+  );
+}
+
+// ---------- sub-components ----------
+
+function AgenticBadge({ header = false }: { header?: boolean }) {
+  const base = "inline-flex items-center gap-1 rounded-full font-medium";
+  if (header) {
+    return (
+      <span className={`${base} bg-amber-100 px-2 py-0.5 text-xs text-amber-800 dark:bg-amber-900 dark:text-amber-200`}>
+        <Sparkles size={10} />
+        Agentic AI
+      </span>
+    );
+  }
+  return (
+    <span className={`${base} bg-amber-200 px-1.5 py-0.5 text-[10px] text-amber-900 dark:bg-amber-800 dark:text-amber-100`}>
+      <Sparkles size={9} />
       Agentic AI
     </span>
   );
 }
 
-// ---------- render helpers ----------
-
 function SubProject({ exp }: { exp: ExperienceWithContractor }) {
-  const bullets = (exp.content?.split("\n") ?? []).filter(
-    (p) => p.trim() !== "",
+  const bullets = (exp.content?.split("\n") ?? []).filter((p) => p.trim() !== "");
+
+  const liClass = exp.isFeatured
+    ? "break-inside-avoid rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/20"
+    : "break-inside-avoid";
+
+  const title = exp.link ? (
+    <a
+      href={exp.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 font-semibold hover:underline"
+    >
+      {exp.company} — {exp.position}
+      <ExternalLink size={12} className="shrink-0 opacity-60" />
+    </a>
+  ) : (
+    <span className="font-semibold">
+      {exp.company} — {exp.position}
+    </span>
   );
 
   return (
-    <li className="break-inside-avoid">
-      <div className="flex flex-wrap items-center gap-2">
-        <h4 className="font-semibold">
-          {exp.company} — {exp.position}
-        </h4>
-        {exp.isFeatured && <AgenticBadge small />}
-      </div>
-      <p className="mb-1.5 text-xs text-muted-foreground">{exp.dates}</p>
-      {exp.techStack.length > 0 && (
-        <div className="mb-2 flex flex-wrap gap-1">
-          {exp.techStack.map((tech) => (
-            <Badge key={`${exp.id}_${tech}`} variant="secondary">
-              {tech}
-            </Badge>
-          ))}
+    <li className={liClass}>
+      <div className="flex items-start gap-2">
+        {exp.companyLogo && <SmallLogo src={exp.companyLogo} company={exp.company} />}
+        <div className="flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            {title}
+            {exp.isFeatured && <AgenticBadge />}
+          </div>
+          <p className="mb-1.5 text-xs text-muted-foreground">{exp.dates}</p>
+          {exp.techStack.length > 0 && (
+            <div className="mb-2 flex flex-wrap gap-1">
+              {exp.techStack.map((tech) => (
+                <Badge key={`${exp.id}_${tech}`} variant="secondary">
+                  {tech}
+                </Badge>
+              ))}
+            </div>
+          )}
+          {bullets.length > 0 && (
+            <ul className="list-disc space-y-0.5 pl-4 text-sm">
+              {bullets.map((b, i) => (
+                <li key={i}>{b}</li>
+              ))}
+            </ul>
+          )}
         </div>
-      )}
-      {bullets.length > 0 && (
-        <ul className="list-disc space-y-0.5 pl-4 text-sm">
-          {bullets.map((b, i) => (
-            <li key={i}>{b}</li>
-          ))}
-        </ul>
-      )}
+      </div>
     </li>
   );
 }
 
 function UngroupedItem({ exp }: { exp: ExperienceWithContractor }) {
-  const bullets = (exp.content?.split("\n") ?? []).filter(
-    (p) => p.trim() !== "",
+  const bullets = (exp.content?.split("\n") ?? []).filter((p) => p.trim() !== "");
+
+  const title = exp.link ? (
+    <a
+      href={exp.link}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 font-semibold hover:underline"
+    >
+      {exp.company} — {exp.position}
+      <ExternalLink size={12} className="shrink-0 opacity-60" />
+    </a>
+  ) : (
+    <span className="font-semibold">
+      {exp.company} — {exp.position}
+    </span>
   );
 
   return (
-    <div className="break-inside-avoid mb-6 flex items-start gap-3">
+    <div className="break-inside-avoid flex items-start gap-3">
       {exp.companyLogo ? (
-        <ContractorLogo src={exp.companyLogo} name={exp.company} size={32} />
+        <SmallLogo src={exp.companyLogo} company={exp.company} />
       ) : (
-        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded bg-muted text-xs font-bold text-muted-foreground">
+        <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted text-[10px] font-bold text-muted-foreground">
           {exp.company[0]}
         </div>
       )}
       <div className="flex-1">
         <div className="flex flex-wrap items-center gap-2">
-          <h3 className="font-semibold">
-            {exp.company} — {exp.position}
-          </h3>
-          {exp.isFeatured && <AgenticBadge small />}
+          {title}
+          {exp.isFeatured && <AgenticBadge />}
         </div>
         <p className="mb-1.5 text-sm text-muted-foreground">{exp.dates}</p>
         {exp.techStack.length > 0 && (
@@ -141,27 +183,17 @@ function UngroupedItem({ exp }: { exp: ExperienceWithContractor }) {
 export default function ContractorGroupedExperience({
   experiences,
 }: ContractorGroupedExperienceProps) {
-  // Sort ascending by order field (lowest order = oldest = shown last when we want newest first)
   const sorted = [...experiences].sort((a, b) => b.order - a.order);
 
-  // Build a Map: contractorCompanyId → experiences[]
-  // and collect ungrouped ones
   const groupMap = new Map<string, ExperienceWithContractor[]>();
-  const ungrouped: ExperienceWithContractor[] = [];
 
   for (const exp of sorted) {
     if (exp.contractorCompany) {
       const key = exp.contractorCompanyId!;
       groupMap.set(key, [...(groupMap.get(key) ?? []), exp]);
-    } else {
-      ungrouped.push(exp);
     }
   }
 
-  // Build a flat render list interleaving groups and ungrouped items
-  // Each item in the list is either a contractor group or a single ungrouped experience.
-  // We determine position by the highest `order` value in each group (since we sorted descending,
-  // the first element of each group has the highest order = most recent).
   type RenderItem =
     | { kind: "group"; key: string; exps: ExperienceWithContractor[] }
     | { kind: "single"; exp: ExperienceWithContractor };
@@ -191,17 +223,15 @@ export default function ContractorGroupedExperience({
       </h2>
 
       <div className="flex flex-col gap-6">
-        {renderItems.map((item, idx) => {
+        {renderItems.map((item) => {
           if (item.kind === "single") {
             return <UngroupedItem key={item.exp.id} exp={item.exp} />;
           }
 
-          // Contractor group card
           const { exps } = item;
           const company = exps[0].contractorCompany!;
           const hasAgentic = exps.some((e) => e.isFeatured);
 
-          // Date range: first item in sorted list = most recent, last = oldest
           const newestDates = exps[0].dates;
           const oldestDates = exps[exps.length - 1].dates;
           const dateRange =
@@ -209,31 +239,45 @@ export default function ContractorGroupedExperience({
               ? newestDates
               : `${oldestDates} – ${newestDates}`;
 
+          const companyName = company.url ? (
+            <a
+              href={company.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 font-bold hover:underline"
+            >
+              {company.name}
+              <ExternalLink size={13} className="shrink-0 opacity-60" />
+            </a>
+          ) : (
+            <span className="font-bold">{company.name}</span>
+          );
+
           return (
             <div
               key={item.key}
-              className="break-inside-avoid rounded-lg border bg-card p-5 shadow-sm print:shadow-none print:border-border"
+              className="break-inside-avoid rounded-lg border bg-card p-5 shadow-sm print:border-border print:shadow-none"
             >
               {/* Umbrella header */}
               <div className="mb-4 flex items-center gap-3">
                 {company.logo ? (
-                  <ContractorLogo src={company.logo} name={company.name} size={40} />
+                  <ContractorLogo src={company.logo} name={company.name} />
                 ) : (
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-muted text-sm font-bold text-muted-foreground">
                     {company.name[0]}
                   </div>
                 )}
-                <div className="flex-1 min-w-0">
+                <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
-                    <h3 className="text-base font-bold">{company.name}</h3>
-                    {hasAgentic && <AgenticBadge />}
+                    <h3 className="text-base">{companyName}</h3>
+                    {hasAgentic && <AgenticBadge header />}
                   </div>
                   <p className="text-xs text-muted-foreground">{dateRange}</p>
                 </div>
               </div>
 
               {/* Sub-projects */}
-              <ol className="space-y-5 border-l border-border pl-5">
+              <ol className="space-y-4 border-l border-border pl-5">
                 {exps.map((exp) => (
                   <SubProject key={exp.id} exp={exp} />
                 ))}

--- a/src/lib/validation/contractorCompany.ts
+++ b/src/lib/validation/contractorCompany.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const createContractorCompanySchema = z.object({
   name: z.string().min(1, { message: "Name is required" }),
   logo: z.string().optional(),
+  url: z.string().url().optional().or(z.literal("")),
 });
 
 export type CreateContractorCompanySchema = z.infer<


### PR DESCRIPTION
- Add url field to ContractorCompany (schema, validation, API, admin form)
- Add missing link field to experience admin form
- Show client company logo on each sub-project in grouped resume view
- Featured (isFeatured) projects now render with MIT-style amber card highlight — border-amber-300 + bg-amber-50 — matching MITCertSpotlight
- Agentic AI badge promoted to amber colour scheme on featured items
- Contractor company name links to company.url when set
- Sub-project title links to exp.link when set