### PR TITLE
fix: alignment, PDF gap, agentic AI highlight, and isFeatured in form

### DIFF
--- a/src/app/api/experiences/route.ts
+++ b/src/app/api/experiences/route.ts
@@ -36,6 +36,7 @@ export const POST = async (req: Request) => {
       dates,
       techStack,
       content,
+      isFeatured,
       contractorCompanyId,
     } = parseResult.data;
     const { userId } = auth();
@@ -55,6 +56,7 @@ export const POST = async (req: Request) => {
         dates,
         techStack,
         content,
+        isFeatured: isFeatured ?? false,
         contractorCompanyId,
       },
     });
@@ -101,6 +103,7 @@ export const PUT = async (req: Request) => {
       dates,
       techStack,
       content,
+      isFeatured,
       contractorCompanyId,
       id,
     } = parseResult.data;
@@ -128,6 +131,7 @@ export const PUT = async (req: Request) => {
         dates,
         techStack,
         content,
+        isFeatured: isFeatured ?? false,
         contractorCompanyId,
       },
     });

--- a/src/components/AddEditExperienceDialog.tsx
+++ b/src/components/AddEditExperienceDialog.tsx
@@ -61,6 +61,7 @@ const AddEditExperienceDialog = ({
       dates: experienceToEdit?.dates || "",
       techStack: experienceToEdit?.techStack || [],
       link: experienceToEdit?.link || undefined,
+      isFeatured: experienceToEdit?.isFeatured ?? false,
       content: experienceToEdit?.content || "",
       contractorCompanyId: experienceToEdit?.contractorCompanyId || undefined,
     },
@@ -240,6 +241,26 @@ const AddEditExperienceDialog = ({
                     <FormControl>
                       <Input type="url" placeholder="https://project-or-company.com" {...field} />
                     </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="isFeatured"
+                render={({ field }) => (
+                  <FormItem>
+                    <div className="flex items-center gap-2">
+                      <FormControl>
+                        <input
+                          type="checkbox"
+                          checked={field.value ?? false}
+                          onChange={(e) => field.onChange(e.target.checked)}
+                          className="h-4 w-4 rounded border-input accent-blue-600"
+                        />
+                      </FormControl>
+                      <FormLabel className="mb-0 cursor-pointer">Agentic AI project</FormLabel>
+                    </div>
                     <FormMessage />
                   </FormItem>
                 )}

--- a/src/components/resume/ContractorGroupedExperience.tsx
+++ b/src/components/resume/ContractorGroupedExperience.tsx
@@ -35,7 +35,13 @@ function ContractorLogo({ src, name }: { src: string; name: string }) {
 
 function SmallLogo({ src, company }: { src: string; company: string }) {
   const [failed, setFailed] = useState(false);
-  if (failed) return null;
+  if (failed) {
+    return (
+      <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted text-[10px] font-bold text-muted-foreground">
+        {company[0]}
+      </div>
+    );
+  }
   return (
     <Image
       src={src}
@@ -94,7 +100,11 @@ function SubProject({ exp }: { exp: ExperienceWithContractor }) {
   return (
     <li className={liClass}>
       <div className="flex items-start gap-2">
-        {exp.companyLogo && <SmallLogo src={exp.companyLogo} company={exp.company} />}
+        {exp.companyLogo ? (
+          <SmallLogo src={exp.companyLogo} company={exp.company} />
+        ) : (
+          <div className="h-5 w-5 shrink-0" />
+        )}
         <div className="flex-1">
           <div className="flex flex-wrap items-center gap-2">
             {title}
@@ -142,14 +152,16 @@ function UngroupedItem({ exp }: { exp: ExperienceWithContractor }) {
     </span>
   );
 
+  const wrapClass = exp.isFeatured
+    ? "break-inside-avoid flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/20"
+    : "break-inside-avoid flex items-start gap-3";
+
   return (
-    <div className="break-inside-avoid flex items-start gap-3">
+    <div className={wrapClass}>
       {exp.companyLogo ? (
         <SmallLogo src={exp.companyLogo} company={exp.company} />
       ) : (
-        <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded bg-muted text-[10px] font-bold text-muted-foreground">
-          {exp.company[0]}
-        </div>
+        <div className="h-5 w-5 shrink-0" />
       )}
       <div className="flex-1">
         <div className="flex flex-wrap items-center gap-2">
@@ -256,7 +268,7 @@ export default function ContractorGroupedExperience({
           return (
             <div
               key={item.key}
-              className="break-inside-avoid rounded-lg border bg-card p-5 shadow-sm print:border-border print:shadow-none"
+              className="rounded-lg border bg-card p-5 shadow-sm print:border-border print:shadow-none"
             >
               {/* Umbrella header */}
               <div className="mb-4 flex items-center gap-3">

--- a/src/lib/validation/experience.ts
+++ b/src/lib/validation/experience.ts
@@ -10,6 +10,7 @@ export const createExperienceSchema = z.object({
   techStack: z.array(z.string()).min(1, { message: "Tech stack is required" }),
   content: z.string().optional(),
   dates: z.string().min(1, { message: "Dates are required" }),
+  isFeatured: z.boolean().optional(),
   contractorCompanyId: z.string().optional(),
 });
 


### PR DESCRIPTION
- isFeatured was missing from validation schema and API — add it so the checkbox actually saves to the database
- Add isFeatured checkbox to experience admin form
- Apply amber card highlight to UngroupedItem too (was only on SubProject)
- SubProject and UngroupedItem now always reserve logo placeholder space so entries without logos stay left-aligned with those that have them
- Remove break-inside-avoid from outer contractor group card to fix the blank page gap after the MIT cert card in PDF print