### PR TITLE
fix: edit form pre-fill, admin nav, and PDF blank gap

### DIFF
--- a/src/app/(admin)/NavBar.tsx
+++ b/src/app/(admin)/NavBar.tsx
@@ -71,6 +71,27 @@ const NavBar = () => {
             <ThemeToggleButton />
           </div>
         </div>
+        <div className="mt-2 flex flex-wrap gap-1 border-t pt-2">
+          {[
+            { href: "/experiences", label: "Experiences" },
+            { href: "/contractor-companies", label: "Contractor Companies" },
+            { href: "/technologies", label: "Technologies" },
+            { href: "/education", label: "Education" },
+            { href: "/notes", label: "Notes" },
+          ].map(({ href, label }) => (
+            <Link
+              key={href}
+              href={href}
+              className={`rounded px-3 py-1 text-sm font-medium transition-colors ${
+                pathname === href
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:bg-muted hover:text-foreground"
+              }`}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
       </nav>
       <AddEditExperienceDialog
         open={showAddeditExperienceDialog}

--- a/src/components/AddEditContractorCompanyDialog.tsx
+++ b/src/components/AddEditContractorCompanyDialog.tsx
@@ -23,7 +23,7 @@ import { Input } from "./ui/input";
 import LoadingButton from "./ui/loading-button";
 import { useRouter } from "next/navigation";
 import { ContractorCompany } from "@prisma/client";
-import { ChangeEvent, useState } from "react";
+import { ChangeEvent, useEffect, useState } from "react";
 import Image from "next/image";
 
 interface AddEditContractorCompanyDialogProps {
@@ -39,6 +39,15 @@ const AddEditContractorCompanyDialog = ({
 }: AddEditContractorCompanyDialogProps) => {
   const [deleteInProgress, setDeleteInProgress] = useState(false);
   const router = useRouter();
+
+  useEffect(() => {
+    form.reset({
+      name: companyToEdit?.name || "",
+      logo: companyToEdit?.logo || undefined,
+      url: companyToEdit?.url || "",
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
 
   const form = useForm<CreateContractorCompanySchema>({
     resolver: zodResolver(createContractorCompanySchema),

--- a/src/components/resume/ContractorGroupedExperience.tsx
+++ b/src/components/resume/ContractorGroupedExperience.tsx
@@ -78,8 +78,8 @@ function SubProject({ exp }: { exp: ExperienceWithContractor }) {
   const bullets = (exp.content?.split("\n") ?? []).filter((p) => p.trim() !== "");
 
   const liClass = exp.isFeatured
-    ? "break-inside-avoid rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/20"
-    : "break-inside-avoid";
+    ? "print:break-inside-avoid rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/20"
+    : "";
 
   const title = exp.link ? (
     <a
@@ -153,8 +153,8 @@ function UngroupedItem({ exp }: { exp: ExperienceWithContractor }) {
   );
 
   const wrapClass = exp.isFeatured
-    ? "break-inside-avoid flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/20"
-    : "break-inside-avoid flex items-start gap-3";
+    ? "print:break-inside-avoid flex items-start gap-3 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 dark:border-amber-700 dark:bg-amber-950/20"
+    : "flex items-start gap-3";
 
   return (
     <div className={wrapClass}>
@@ -234,7 +234,7 @@ export default function ContractorGroupedExperience({
         Experience
       </h2>
 
-      <div className="flex flex-col gap-6">
+      <div className="space-y-6">
         {renderItems.map((item) => {
           if (item.kind === "single") {
             return <UngroupedItem key={item.exp.id} exp={item.exp} />;

--- a/src/components/resume/MITCertSpotlight.tsx
+++ b/src/components/resume/MITCertSpotlight.tsx
@@ -15,7 +15,7 @@ export default function MITCertSpotlight() {
   return (
     <section
       aria-labelledby="mit-cert-heading"
-      className="mb-8 rounded-xl border border-amber-300 bg-amber-50 px-6 py-5 shadow-sm dark:border-amber-700 dark:bg-amber-950/20"
+      className="mb-8 rounded-xl border border-amber-300 bg-amber-50 px-6 py-5 shadow-sm print:break-after-avoid dark:border-amber-700 dark:bg-amber-950/20"
     >
       <div className="flex items-start gap-4">
         <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-amber-200 dark:bg-amber-800">


### PR DESCRIPTION
- AddEditContractorCompanyDialog: add useEffect to reset form on open, so editing a company always pre-fills current name/logo/url
- NavBar: add navigation links row below header for all admin sections (Experiences, Contractor Companies, Technologies, Education, Notes) with active-page highlight
- MITCertSpotlight: add print:break-after-avoid to prevent forced page break after the cert card
- ContractorGroupedExperience: replace flex flex-col gap-6 with space-y-6 (block layout, Chrome print-friendly); scope break-inside-avoid to print: prefix and only on featured items