### PR TITLE
feat: move Skills & Technologies above Experience on resume

### DIFF
--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -20,8 +20,8 @@ export default async function ResumePage() {
       <article>
         <ResumeHeader />
         <MITCertSpotlight />
-        <ContractorGroupedExperience experiences={experiences} />
         <SkillsGrid technologies={technologies} />
+        <ContractorGroupedExperience experiences={experiences} />
         <EducationSection />
       </article>
     </main>


### PR DESCRIPTION
Compact skills grid fills remaining page-1 space after the MIT card, eliminating the blank gap. Experience section now starts cleanly at the top of page 2. Also matches startup resume best practice of showing tech stack early.